### PR TITLE
app.py: return 409 if OCR present

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ async def create_upload_file(
     except ocrmypdf.PriorOcrFoundError as ex:
         raise HTTPException(
             detail="page already has text! Set force-ocr to continue",
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_409_CONFLICT,
         ) from ex
     except ocrmypdf.PdfMergeFailedError as ex:
         raise HTTPException(


### PR DESCRIPTION
Return a 409 CONFLICT http code when the ocr is already present. This
can help clients to differentiate it from other client errors.
For example it could ignore this error and continue using its old pdf
file because a 409 will only be returned for files that already have
ocred content.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
